### PR TITLE
Tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in rack-heartbeat.gemspec
 gemspec
+
+gem 'coveralls', :group => :test, :require => false

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Once the gem is installed, you're done.  Just browse to localhost:300/heartbeat 
 If you want to customize the url for any reason, you can configure that, too:
 
 ```ruby
-#config/initilializers/rack_heartbeat.rb
+#config/initializers/rack_heartbeat.rb
 Rack::Heartbeat.setup do |config|
   config.heartbeat_path = 'health-check.txt'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.test_files = FileList['test/**/test*.rb']
+  t.verbose = true
+end

--- a/lib/rack/heartbeat.rb
+++ b/lib/rack/heartbeat.rb
@@ -3,9 +3,18 @@ module Rack
   # that returns status 200 and content OK when executed.
 
   class Heartbeat
-    cattr_accessor :heartbeat_path
     @@heartbeat_path = 'heartbeat'
-    
+
+    class << self
+      def heartbeat_path
+        @@heartbeat_path
+      end
+
+      def heartbeat_path=(path)
+        @@heartbeat_path = path
+      end
+    end
+
     def initialize(app)
       @app = app
     end
@@ -17,6 +26,10 @@ module Rack
       else
         @app.call(env)
       end
+    end
+
+    def heartbeat_path
+      self.class.heartbeat_path
     end
 
     def self.setup

--- a/rack-heartbeat.gemspec
+++ b/rack-heartbeat.gemspec
@@ -12,8 +12,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "rack-heartbeat"
   gem.require_paths = ["lib"]
-  gem.version       = '1.0'
+  gem.version       = '1.0.1'
 
-  # deps
-  gem.add_dependency('rack')
+  gem.add_development_dependency('minitest')
+  gem.add_development_dependency('rack-test')
+  gem.add_runtime_dependency('rack')
 end

--- a/rack-heartbeat.gemspec
+++ b/rack-heartbeat.gemspec
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-#require 'rack'
 
 Gem::Specification.new do |gem|
   gem.authors       = ["James Cox"]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'rack-heartbeat'

--- a/test/rack/test_heartbeat.rb
+++ b/test/rack/test_heartbeat.rb
@@ -1,0 +1,57 @@
+require 'helper'
+
+class Rack::TestHeartbeat < Minitest::Test
+  def setup
+    @app = Minitest::Mock.new
+    @heartbeat = Rack::Heartbeat.new(@app)
+  end
+
+  def teardown
+    Rack::Heartbeat.setup do |config|
+      config.heartbeat_path = 'heartbeat'
+    end
+  end
+
+  def test_initialize_sets_default_heartbeat_path
+    assert_match(/\Aheartbeat\z/, @heartbeat.heartbeat_path)
+  end
+
+  def test_call_when_env_empty_sends_app_call
+    env = {}
+
+    @app.expect :call, nil, [env]
+    @heartbeat.call(env)
+    @app.verify
+  end
+
+  def test_call_when_path_info_is_nil_sends_app_call
+    env = {'PATH_INFO' => nil}
+
+    @app.expect :call, nil, [env]
+    @heartbeat.call(env)
+    @app.verify
+  end
+
+  def test_call_when_path_info_does_not_match_heartbeat_sends_app_call
+    env = {'PATH_INFO' => 'some-path'}
+
+    @app.expect :call, nil, [env]
+    @heartbeat.call(env)
+    @app.verify
+  end
+
+  def test_call_when_path_info_matches_heartbeat_path_returns_200_response
+    env = {'PATH_INFO' => '/heartbeat'}
+
+    assert_equal [200, {'Content-Type' => 'text/plain'}, ['OK']], @heartbeat.call(env)
+  end
+
+  def test_setup_configures_heartbeat_path
+    expected = 'health-check.txt'
+    Rack::Heartbeat.setup do |config|
+      config.heartbeat_path = expected
+    end
+
+    assert_match expected, Rack::Heartbeat.heartbeat_path
+  end
+end


### PR DESCRIPTION
:information_desk_person: tl; dr, These changes add tests for this gem's existing functionality.

The existing gem functionality expected to be run within Rails, e.g. assuming that  `cattr_accessor`/`mattr_accessor` is available. To keep the library useable _as purely Rack middleware_, I've emulated the `cattr_accessor`-like behaviour and removed the implicit use of ActiveSupport methods.

I've used `Minitest` for the test suite to keep the footprint relatively light and the tests fast. I also added `Coveralls` to generate code coverage for the test suite.

Please also note that these changes bump the gem version to 1.0.1.