### PR TITLE
fix deprecation warning in Rails 5.

### DIFF
--- a/lib/rack/heartbeat/railtie.rb
+++ b/lib/rack/heartbeat/railtie.rb
@@ -2,7 +2,7 @@ module Rack
 
   class Heartbeat::Railtie < Rails::Railtie
     initializer "rack.heartbeat.initializer" do |app|
-      app.middleware.insert 0, 'Rack::Heartbeat'
+      app.middleware.insert 0, Rack::Heartbeat
     end
   end
 


### PR DESCRIPTION
The following message appears when this middleware is integrated with rails 5.

```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "Rack::Heartbeat" => Rack::Heartbeat

 (called from <top (required)> at [...]
```